### PR TITLE
Remove unnecessary -- for forwarding arguments from yarn to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deps:clean": "lerna clean -y && del-cli node_modules",
     "deps:upgrade": "del-cli yarn.lock && yarn run deps:clean && yarn install && yarn run bootstrap && yarn run build",
     "lint": "eslint packages/*/src packages/*/__tests__",
-    "lint:fix": "yarn run lint -- --fix",
+    "lint:fix": "yarn run lint --fix",
     "test:unit": "BABEL_ENV=test jest --config jest.config.js",
     "test:ci": "BABEL_ENV=test jest --ci --config jest.config.ci.js --runInBand",
     "test:types": "flow check --merge-timeout 0",


### PR DESCRIPTION
This removes the warning that yarn prints out every time `lint:fix` is ran:

```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```

Since we explicitly say that `mainframe-os` [requires yarn version to be 1.13 or higher](https://github.com/MainframeHQ/mainframe-os#prerequisites), there's no need for this any more.