### PR TITLE
make 'to' field optional for eth tx params in client schema

### DIFF
--- a/packages/client/src/schema.js
+++ b/packages/client/src/schema.js
@@ -305,7 +305,7 @@ export const WALLET_ADD_HD_ACCOUNT_SCHEMA = {
 export const ETH_TRANSACTION_SCHEMA = {
   nonce: 'string',
   from: 'string',
-  to: 'string',
+  to: { type: 'string', optional: true },
   gas: 'string',
   gasPrice: 'string',
   data: { type: 'string', optional: true },


### PR DESCRIPTION
Fixes not being able to deploy a contract where there is no `to` address to be assigned.