### PR TITLE
Check if filePaths is undefined instead of zero length

### DIFF
--- a/packages/launcher/src/main/rpc/app.js
+++ b/packages/launcher/src/main/rpc/app.js
@@ -323,7 +323,7 @@ export const sandboxed = {
           ctx.window,
           { title: 'Select file to upload', buttonLabel: 'Upload' },
           async filePaths => {
-            if (filePaths.length === 0) {
+            if (filePaths === undefined) {
               // No file selected
               resolve(false)
             } else {


### PR DESCRIPTION
I know it's a one line PR, but just to provide some context :)

When I was testing out the storage APIs, I noticed that I was getting this error when closing the upload window without selecting a file:

![image](https://user-images.githubusercontent.com/1229422/57135517-f93dfa80-6da9-11e9-8574-2756a2d3428a.png)

After looking at the Electron documentation I realized that `undefined` is the expected return in this case: https://electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options-callback
